### PR TITLE
Updated file paths for Windows

### DIFF
--- a/src/Sioen/Countries.php
+++ b/src/Sioen/Countries.php
@@ -37,7 +37,7 @@ class Countries
         $path = dirname(__FILE__) . '/../../';
 
         // if our class is loaded from composer, the path to umpirski changes
-        if (strpos(dirname(__FILE__), '/vendor/') !== false) {
+        if (strpos(dirname(__FILE__), 'vendor') !== false) {
             $path .= '../../../';
         }
 


### PR DESCRIPTION
Due to the forward slashes in de search string for the vendor folder, the folder is never detected on windows machines (file paths are displayed with a backslash).
